### PR TITLE
fix url path case insensitive

### DIFF
--- a/go2index/index.js
+++ b/go2index/index.js
@@ -856,10 +856,10 @@ class googleDrive {
     let requestOption = await this.requestOption();
     let response = await fetch(url, requestOption);
     let obj = await response.json();
-    if (obj.files[0] == undefined) {
-      return null;
-    }
-    return obj.files[0].id;
+    if (!obj.files) return null
+    const same_name = obj.files.find(v => v.name === name)
+    if (!same_name) return null
+    return same_name.id
   }
 
   async accessToken() {


### PR DESCRIPTION
google drive搜索文件的api 'name=...' 默认是大小写不敏感的，不能简单的返回第一个搜索结果。
比如，根目录下有两个文件夹 haha 和 Haha，那么用户直接访问 `/haha`，和`/Haha`都会返回haha里的内容。
此PR修复了此问题。